### PR TITLE
Build artifacts

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -1,0 +1,46 @@
+name: Build
+
+on:
+ push:
+  paths:
+  - '.github/workflows/Build.yml'
+  - 'src/**.c'
+  - 'src/**.h'
+  - '**/CMakeLists.txt'
+ pull_request:
+  paths:
+  - '.github/workflows/Build.yml'
+  - 'src/**.c'
+  - 'src/**.h'
+  - '**/CMakeLists.txt'
+
+defaults:
+ run:
+  shell: bash
+
+jobs:
+
+ Build:
+  runs-on: windows-latest
+  steps:
+
+  - name: Clone
+    uses: actions/checkout@v2
+
+  - name: Prepare
+    run:  cmake -B Build -A Win32
+
+  - name: Debug build
+    run:  cmake --build Build --config Debug
+
+  - name: Release build
+    run:  cmake --build Build --config Release
+
+  - name: Artifact
+    uses: actions/upload-artifact@v3
+    with:
+     name: Fallout2-RE
+     path: |
+      Build/*/fallout2-re.exe
+      Build/*/fallout2-re.pdb
+     retention-days: 14


### PR DESCRIPTION
Adds GitHub Action which builds executables (Debug and Release config), and uploads .zip which can be accessed via Actions tab. Allows people without VS knowledge to test new stuff minutes after it's commited and reduces manual labor.

Artifacts are set to be removed after 14 days (instead of default 90); should be enough for backtracking without polluting artifacts quota.