### PR TITLE
Include assert.h to define static_assert macro

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <assert.h>
 
 static_assert(sizeof(CacheEntry) == 32, "wrong size");
 static_assert(sizeof(Cache) == 84, "wrong size");

--- a/src/core.h
+++ b/src/core.h
@@ -7,6 +7,7 @@
 #include "window.h"
 
 #include <stdbool.h>
+#include <assert.h>
 
 #define MOUSE_DEFAULT_CURSOR_WIDTH 8
 #define MOUSE_DEFAULT_CURSOR_HEIGHT 8

--- a/src/heap.c
+++ b/src/heap.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 
 static_assert(sizeof(HeapBlockHeader) == 16, "wrong size");
 static_assert(sizeof(HeapBlockFooter) == 4, "wrong size");

--- a/src/nevs.c
+++ b/src/nevs.c
@@ -5,6 +5,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 
 static_assert(sizeof(Nevs) == 60, "wrong size");
 

--- a/src/obj_types.h
+++ b/src/obj_types.h
@@ -1,6 +1,8 @@
 #ifndef OBJ_TYPES_H
 #define OBJ_TYPES_H
 
+#include <assert.h>
+
 // Rotation
 typedef enum Rotation {
     ROTATION_NE, // 0

--- a/src/region.c
+++ b/src/region.c
@@ -5,6 +5,7 @@
 
 #include <limits.h>
 #include <string.h>
+#include <assert.h>
 
 static_assert(sizeof(Region) == 140, "wrong size");
 

--- a/src/sound.c
+++ b/src/sound.c
@@ -9,6 +9,7 @@
 #include <mmsystem.h>
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 
 static_assert(sizeof(Sound) == 156, "wrong size");
 

--- a/src/sound_decoder.h
+++ b/src/sound_decoder.h
@@ -3,6 +3,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <assert.h>
 
 #define SOUND_DECODER_IN_BUFFER_SIZE (512)
 

--- a/src/text_font.h
+++ b/src/text_font.h
@@ -2,6 +2,7 @@
 #define TEXT_FONT_H
 
 #include <stdbool.h>
+#include <assert.h>
 
 // The maximum number of text fonts.
 #define TEXT_FONT_MAX (10)

--- a/src/window.h
+++ b/src/window.h
@@ -6,6 +6,7 @@
 #include "region.h"
 
 #include <stdbool.h>
+#include <assert.h>
 
 #define MANAGED_WINDOW_COUNT (16)
 


### PR DESCRIPTION
This commit should work flawlessly also with MSVC, as explained in [here](https://docs.microsoft.com/en-us/cpp/c-language/static-assert-c?view=msvc-170) the `static_assert` macro is defined in `assert.h`