### PR TITLE
c_dfDIKeyboard can't be static because already defined as extern in dinput.h

### DIFF
--- a/src/dinput.c
+++ b/src/dinput.c
@@ -293,7 +293,7 @@ static const DIOBJECTDATAFORMAT dfDIKeyboard[] = {
 };
 
 // 0x4FDF20
-static const DIDATAFORMAT c_dfDIKeyboard = {
+const DIDATAFORMAT c_dfDIKeyboard = {
     sizeof(DIDATAFORMAT),
     sizeof(DIOBJECTDATAFORMAT),
     DIDF_RELAXIS,


### PR DESCRIPTION
At least, that's how's defined in [mingw32/include/dinput.h](https://github.com/mirror/mingw-w64/blob/master/mingw-w64-headers/include/dinput.h#L2150)